### PR TITLE
Improve the isolation level (read committed) by using non-temporal store

### DIFF
--- a/lbtree-src/lbtree.cc
+++ b/lbtree-src/lbtree.cc
@@ -732,10 +732,15 @@ Again2:
        if (slot<3) {
            // 1.3.1 write word 0
            meta.v.bitmap= bitmap;
+
+#ifdef NONTEMP
+           lp->setWord0_temporal(&meta);
+#else
            lp->setWord0(&meta);
 
            // 1.3.2 flush
            clwb(lp); sfence();
+#endif           
 
            return;
        }
@@ -760,8 +765,12 @@ Again2:
 
          // 1.4.3 change meta and flush line 0
          meta.v.bitmap= bitmap;
+#ifdef NONTEMP
+         lp->setBothWords_temporal(&meta);
+#else
          lp->setBothWords(&meta);
          clwb(lp); sfence();
+#endif         
 
          return;
        }
@@ -1138,9 +1147,12 @@ Again3:
 
        meta.v.lock= 0;  // clear lock in temp meta
        meta.v.bitmap &= ~(1<<ppos[0]);  // mark the bitmap to delete the entry
+#ifdef NONTEMP
+       lp->setWord0_temporal(&meta);
+#else
        lp->setWord0(&meta);
        clwb(lp); sfence();
-
+#endif
        return;
 
     } // end of more than one key

--- a/lbtree-src/lbtree.h
+++ b/lbtree-src/lbtree.h
@@ -36,6 +36,9 @@
 
 #define LEAF_KEY_NUM        (14) 
 
+// use non-temporal store for correct isolation
+#define NONTEMP 1
+
 /* ---------------------------------------------------------------------- */
 /**
  * Pointer8B defines a class that can be assigned to either bnode or bleaf.
@@ -136,6 +139,12 @@ typedef union bleafMeta {
     } v;
 } bleafMeta;
 
+void movnt64(uint64_t *dest, uint64_t const src, bool front, bool back) {
+    if (front) sfence();
+    _mm_stream_si64((long long int *)dest, (long long int) src);
+    if (back) sfence();
+}
+
 /**
  * bleaf: leaf node
  *
@@ -170,6 +179,16 @@ public:
        my_meta->word8B[0]= m->word8B[0];
     }
 
+    void setWord0_temporal(bleafMeta *m){
+       bleafMeta * my_meta= (bleafMeta *)this;
+       movnt64((uint64_t*)&my_meta->word8B[0], m->word8B[0], false, true);
+    }
+
+    void setBothWords_temporal(bleafMeta *m) {
+       bleafMeta * my_meta= (bleafMeta *)this;
+       my_meta->word8B[1]= m->word8B[1];
+       movnt64((uint64_t*)&my_meta->word8B[0], m->word8B[0], false, true);
+    }
 }; // bleaf
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
This version fixed the weak isolation [issue](https://github.com/schencoding/lbtree/issues/2). 
The insert/delete operations employ the non-temporal stores for lock release so that the isolation level is at least read committed. 
